### PR TITLE
Android build fixes

### DIFF
--- a/android/src/main/kotlin/com/keevault/flutter_autofill_service/DynamicLevelLoggingProvider.kt
+++ b/android/src/main/kotlin/com/keevault/flutter_autofill_service/DynamicLevelLoggingProvider.kt
@@ -4,16 +4,21 @@ import org.tinylog.Level
 import org.tinylog.core.TinylogLoggingProvider
 import org.tinylog.format.MessageFormatter
 
-class DynamicLevelLoggingProvider : TinylogLoggingProvider() {
+class DynamicLevelLoggingProvider(val _logger : TinylogLoggingProvider) {
+    private var logger : TinylogLoggingProvider
+
+    init {
+        this.logger = _logger
+    }
 
     @Volatile
     var activeLevel: Level = Level.TRACE;
 
-    override fun isEnabled(depth: Int, tag: String?, level: Level?): Boolean {
-        return activeLevel <= level && super.isEnabled(depth + 1, tag, level)
+    fun isEnabled(depth: Int, tag: String?, level: Level?): Boolean {
+        return activeLevel <= level && this.logger.isEnabled(depth + 1, tag, level)
     }
 
-    override fun log(
+    fun log(
         depth: Int,
         tag: String?,
         level: Level?,
@@ -23,11 +28,11 @@ class DynamicLevelLoggingProvider : TinylogLoggingProvider() {
         arguments: Array<Any>?
     ) {
         if (activeLevel <= level) {
-            super.log(depth + 1, tag, level, exception, formatter, obj, arguments ?: emptyArray<Any>())
+            this.logger.log(depth + 1, tag, level, exception, formatter, obj, arguments ?: emptyArray<Any>())
         }
     }
 
-    override fun log(
+    fun log(
         loggerClassName: String?,
         tag: String?,
         level: Level?,
@@ -37,7 +42,7 @@ class DynamicLevelLoggingProvider : TinylogLoggingProvider() {
         arguments: Array<Any>?
     ) {
         if (activeLevel <= level) {
-            super.log(loggerClassName, tag, level, exception, formatter, obj, arguments ?: emptyArray<Any>())
+            this.logger.log(loggerClassName, tag, level, exception, formatter, obj, arguments ?: emptyArray<Any>())
         }
     }
 

--- a/android/src/main/kotlin/com/keevault/flutter_autofill_service/FlutterAutofillPlugin.kt
+++ b/android/src/main/kotlin/com/keevault/flutter_autofill_service/FlutterAutofillPlugin.kt
@@ -39,6 +39,7 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.tinylog.Level
+import org.tinylog.core.TinylogLoggingProvider
 
 
 private val logger = KotlinLogging.logger {}
@@ -167,7 +168,7 @@ class FlutterAutofillPluginImpl(val context: Context) : MethodCallHandler,
 
                 // Make sure we have the latest log level configuration
                 val provider =
-                    org.tinylog.provider.ProviderRegistry.getLoggingProvider() as DynamicLevelLoggingProvider
+                     DynamicLevelLoggingProvider(org.tinylog.provider.ProviderRegistry.getLoggingProvider() as TinylogLoggingProvider)
                 provider.activeLevel =
                     if (autofillPreferenceStore.autofillPreferences.enableDebug) Level.TRACE else Level.OFF
                 result.success(true)

--- a/android/src/main/kotlin/com/keevault/flutter_autofill_service/FlutterAutofillService.kt
+++ b/android/src/main/kotlin/com/keevault/flutter_autofill_service/FlutterAutofillService.kt
@@ -25,6 +25,7 @@ import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.tinylog.Level
+import org.tinylog.core.TinylogLoggingProvider
 import org.tinylog.policies.DynamicPolicy
 import java.util.*
 
@@ -48,7 +49,7 @@ class FlutterAutofillService : AutofillService() {
         super.onCreate()
         autofillPreferenceStore = AutofillPreferenceStore.getInstance(applicationContext)
         System.setProperty("logs.folder", filesDir.absolutePath + "/logs");
-        val provider = org.tinylog.provider.ProviderRegistry.getLoggingProvider() as DynamicLevelLoggingProvider;
+        val provider = DynamicLevelLoggingProvider(org.tinylog.provider.ProviderRegistry.getLoggingProvider() as TinylogLoggingProvider);
         //TODO: somehow force tracing to logcat at all times when in debug rather than release build mode?
         provider.activeLevel = if (autofillPreferenceStore.autofillPreferences.enableDebug) Level.TRACE else Level.OFF;
         logger.debug { "Autofill service was created. debug: ${autofillPreferenceStore.autofillPreferences.enableDebug}" }
@@ -60,7 +61,7 @@ class FlutterAutofillService : AutofillService() {
         // Make sure we have the latest log level configuration each time we are asked to start the autofill procedure.
         // Android may re-use the same process for a long time and we may have had the shared preferences updated from
         // a different process/task in the mean time.
-        val provider = org.tinylog.provider.ProviderRegistry.getLoggingProvider() as DynamicLevelLoggingProvider;
+        val provider = DynamicLevelLoggingProvider(org.tinylog.provider.ProviderRegistry.getLoggingProvider() as TinylogLoggingProvider);
         provider.activeLevel = if (autofillPreferenceStore.autofillPreferences.enableDebug) Level.TRACE else Level.OFF;
 
         // If the user has just deleted the autofill logs through the main app, the file handle

--- a/android/src/main/kotlin/com/keevault/flutter_autofill_service/InlinePresentationHelper.kt
+++ b/android/src/main/kotlin/com/keevault/flutter_autofill_service/InlinePresentationHelper.kt
@@ -63,11 +63,26 @@ object InlinePresentationHelper {
         } else null
     }
 
+    private fun getExplicitIntent(
+      context: Context
+    ): Intent {
+        val explicitIntent = Intent()
+        explicitIntent.setPackage(context.packageName)
+        return explicitIntent
+    }
+
     private fun getAttributionPendingIntent(
         pendingIntent: PendingIntent?,
         context: Context
     ): PendingIntent =
-        pendingIntent ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        pendingIntent ?: if (Build.VERSION.SDK_INT >= 34) {
+            PendingIntent.getService(
+                context,
+                0,
+                getExplicitIntent(context),
+                PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            )
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             PendingIntent.getService(
                 context,
                 0,

--- a/android/src/main/kotlin/com/keevault/flutter_autofill_service/IntentHelpers.kt
+++ b/android/src/main/kotlin/com/keevault/flutter_autofill_service/IntentHelpers.kt
@@ -2,6 +2,7 @@ package com.keevault.flutter_autofill_service
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 
 object IntentHelpers {
     fun getStartIntent(activityName: String, packageNames: Set<String>, webDomains: Set<WebDomain>, context: Context, autofillMode: String, saveInfo: SaveInfoMetadata?): Intent {
@@ -15,6 +16,10 @@ object IntentHelpers {
                 AutofillMetadata.EXTRA_NAME,
                 AutofillMetadata(packageNames, webDomains, saveInfo).toJsonString()
         )
+        if (Build.VERSION.SDK_INT >= 34) {
+            // Make the intent explicit to allow mutability
+            startIntent.setPackage(context.packageName)
+        }
 
         // Note: Do not make a pending intent immutable by using PendingIntent.FLAG_IMMUTABLE
         // as the platform needs to fill in the authentication arguments.


### PR DESCRIPTION
Fixes `org.tinylog.core.TinylogLoggingProvider cannot be cast to com.keevault.flutter_autofill_service.DynamicLevelLoggingProvider` on Kotlin 1.8.22

**Edit 1:** now includes fixes for U+ targets